### PR TITLE
Setup basic deployment tasks, set proper production hostname.

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -10,7 +10,7 @@ use Mix.Config
 # which you should run after static files are built and
 # before starting your production server.
 config :mehr_schulferien, MehrSchulferienWeb.Endpoint,
-  url: [host: "example.com", port: 80],
+  url: [host: "beta.mehr-schulferien.de", port: 80],
   cache_static_manifest: "priv/static/cache_manifest.json"
 
 # Do not print debug messages in production

--- a/lib/mehr_schulferien/release_tasks.ex
+++ b/lib/mehr_schulferien/release_tasks.ex
@@ -1,0 +1,18 @@
+defmodule MehrSchulferien.ReleaseTasks do
+  @app :mehr_schulferien
+
+  def migrate do
+    for repo <- repos() do
+      {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :up, all: true))
+    end
+  end
+
+  def rollback(repo, version) do
+    {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :down, to: version))
+  end
+
+  defp repos do
+    Application.load(@app)
+    Application.fetch_env!(@app, :ecto_repos)
+  end
+end


### PR DESCRIPTION
You can run a task on the server like:
`$ ./app/release/bin/mehr_schulferien eval "MehrSchulferien.ReleaseTasks.migrate"`

This has some gotchas:
1. if the app is currently running, and you remove or rename a column that an
   Ecto struct depends on things will start to break.

2. if you start the new version of the app before running migrations, and
   an Ecto struct depends on a column that doesn't exist, the app will
   not start

There are some workarounds for this, the one I use the most often is two step
deploys.

Eg, to remove a column:

Deploy 1 - remove the struct key
Deploy 2 - write the migration to drop the column

More information about deployment tasks (like migrating a database) can be
found here:
https://hexdocs.pm/phoenix/releases.html#ecto-migrations-and-custom-commands

A more complex working example can be found here:
https://github.com/piisalie/aws_training_elixirconf_2019/blob/master/4_the_details/exercise/web_app/lib/web_app/release_tasks.ex