### PR TITLE
Fixed bug in vacation calendar summaries

### DIFF
--- a/lib/mehr_schulferien_web/templates/partial/_vacation_calendar.html.eex
+++ b/lib/mehr_schulferien_web/templates/partial/_vacation_calendar.html.eex
@@ -49,7 +49,7 @@
         </table>
       </div>
       <div class="footer">
-        <% public_periods = Enum.filter(@public_periods, & &1.is_public_holiday) %>
+        <% public_periods = Enum.filter(public_periods, & &1.is_public_holiday) %>
         <%= unless Enum.empty?(public_periods) and Enum.empty?(school_periods) do %>
           <div class="padding">
             <div class="row">


### PR DESCRIPTION
This fixes a bug in the summary section of the vacation calendar - all the public periods were being listed multiple times.