### PR TITLE
Updated bridge day panel schema events

### DIFF
--- a/lib/mehr_schulferien_web/templates/partial/_bridge_day_panel.html.eex
+++ b/lib/mehr_schulferien_web/templates/partial/_bridge_day_panel.html.eex
@@ -64,8 +64,8 @@
     "@context": "http://schema.org",
     "@type": "Event",
     "name": "<%= max_days %> Tage frei für <%= if bridge_days_number == 1 do %>Brückentag<% else %>Brückentage<% end %>",
-    "startDate" : "<%= first_day %>",
-    "endDate" : "<%= last_day %>",
+    "startDate" : "<%= @bridge_day.starts_on %>",
+    "endDate" : "<%= @bridge_day.ends_on %>",
     "location": {
       "@type": "Place",
       "name": "<%= @federal_state.name %>",


### PR DESCRIPTION
In the bridge day panel schema events, changed the startDate and endDate to the start and end date of the bridge day period (previously, these dates were set to the first and last days of the whole possible holiday).