### PR TITLE
Updated root page table to show vacation type name

### DIFF
--- a/lib/mehr_schulferien_web/templates/partial/_current_calendar.html.eex
+++ b/lib/mehr_schulferien_web/templates/partial/_current_calendar.html.eex
@@ -35,7 +35,7 @@
         <% periods = place[:periods] %>
         <%= for {federal_state, periods} <- periods do %>
           <tr>
-            <td><%= link federal_state.name, to: Routes.federal_state_path(@conn, :show, country.slug, federal_state.slug) %></td>
+            <td rowspan="2"><%= link federal_state.name, to: Routes.federal_state_path(@conn, :show, country.slug, federal_state.slug) %></td>
             <%= for day <- @days do %>
               <% td_html_class = ViewHelpers.get_html_class(day, periods) %>
               <td class="text-center <%= td_html_class %>">
@@ -49,6 +49,24 @@
               </td>
             <% end %>
             <%= if Enum.count(@days) < 360 do %><td><%= link "➡️", to: Routes.page_path(@conn, :full_year) %></td><% end  %>
+            </tr>
+              <%= for day <- @days do %>
+                <%= if days_period = MehrSchulferienWeb.PageView.get_days_period(day, periods) do %>
+                  <%= if MehrSchulferienWeb.PageView.display_period_info?(day, @days, days_period) do %>
+                    <% colspan = MehrSchulferienWeb.PageView.get_period_colspan(day, days_period) %>
+                    <td class="<%= days_period.html_class %>" colspan="<%= colspan %>">
+                      <%= MehrSchulferienWeb.PageView.show_period_info(days_period, colspan) %>
+                    </td>
+                  <% else %>
+                    <%= if days_period.holiday_or_vacation_type.name == "Wochenende" or days_period.is_school_vacation == false do %>
+                      <td></td>
+                    <% end %>
+                  <% end %>
+                <% else %>
+                  <td></td>
+                <% end %>
+              <% end %>
+            <tr>
           </tr>
         <% end %>
       <% end %>

--- a/lib/mehr_schulferien_web/views/page_view.ex
+++ b/lib/mehr_schulferien_web/views/page_view.ex
@@ -1,9 +1,45 @@
 defmodule MehrSchulferienWeb.PageView do
   use MehrSchulferienWeb, :view
 
-  alias MehrSchulferien.Locations
+  alias MehrSchulferien.{Calendars, Locations}
 
   def number_schools() do
     Locations.number_schools()
+  end
+
+  def get_days_period(date, periods) do
+    case Calendars.find_all_periods(periods, date) do
+      [] -> nil
+      [period] -> period
+      periods -> periods |> Enum.sort(&(&1.display_priority >= &2.display_priority)) |> hd
+    end
+  end
+
+  def display_period_info?(date, dates, period) do
+    if date == hd(dates) do
+      true
+    else
+      period.is_school_vacation == true && date == period.starts_on
+    end
+  end
+
+  def get_period_colspan(date, period) do
+    Date.diff(period.ends_on, date) + 1
+  end
+
+  def show_period_info(period, colspan) when colspan < 10 do
+    show_period_name(period)
+  end
+
+  def show_period_info(period, _) do
+    show_period_name(period) <> " " <> show_period_date(period)
+  end
+
+  defp show_period_name(period) do
+    "#{period.holiday_or_vacation_type.colloquial}"
+  end
+
+  defp show_period_date(period) do
+    "(#{ViewHelpers.format_date_range(period.starts_on, period.ends_on, :short)})"
   end
 end


### PR DESCRIPTION
This PR completes most of the work on #472

The issue still needs fine tuning with respect to holidays that fill a small number of days.