### PR TITLE
Updated ICalendar implementation

### DIFF
--- a/lib/mehr_schulferien_web/controllers/api/v2/i_cal_controller.ex
+++ b/lib/mehr_schulferien_web/controllers/api/v2/i_cal_controller.ex
@@ -1,32 +1,44 @@
 defmodule MehrSchulferienWeb.Api.V2.ICalController do
   use MehrSchulferienWeb, :controller
 
-  alias MehrSchulferien.{Calendars.DateHelpers, Locations, Periods}
+  alias MehrSchulferien.{Locations, Periods}
 
-  def show(conn, %{"slug" => slug, "vacation_types" => vacation_types}) do
+  def show(conn, %{"slug" => slug, "vacation_types" => vacation_types, "year" => year}) do
     location = Locations.get_location_by_slug!(slug)
     location_ids = Locations.recursive_location_ids(location)
-    current_year = DateHelpers.today_berlin().year
-    {:ok, start_date} = Date.new(current_year, 1, 1)
-    {:ok, end_date} = Date.new(current_year + 2, 12, 31)
+    year = String.to_integer(year)
+    {:ok, start_date} = Date.new(year, 8, 1)
+    {:ok, end_date} = Date.new(year + 1, 7, 31)
     periods = list_periods(vacation_types, location_ids, start_date, end_date)
 
     conn
-    |> update_headers(slug)
+    |> update_headers(location.name, year)
     |> render("icalendar.ics", location: location, periods: periods)
   end
 
   defp list_periods("all", location_ids, start_date, end_date) do
-    Periods.list_school_periods(location_ids, start_date, end_date) ++
-      Periods.list_public_periods(location_ids, start_date, end_date)
+    periods =
+      list_school_periods(location_ids, start_date, end_date) ++
+        Periods.list_public_periods(location_ids, start_date, end_date)
+
+    Enum.sort(periods, &(Date.compare(&1.starts_on, &2.starts_on) != :gt))
   end
 
   defp list_periods(_, location_ids, start_date, end_date) do
-    Periods.list_school_periods(location_ids, start_date, end_date)
+    list_school_periods(location_ids, start_date, end_date)
   end
 
-  defp update_headers(conn, slug) do
-    filename = "#{String.replace(slug, ".", "_")}_icalendar.ics"
+  defp list_school_periods(location_ids, start_date, end_date) do
+    location_ids
+    |> Periods.list_school_periods(start_date, end_date)
+    |> Enum.reject(
+      &(&1.holiday_or_vacation_type.name == "Sommer" and
+          Date.compare(&1.starts_on, start_date) == :lt)
+    )
+  end
+
+  defp update_headers(conn, name, year) do
+    filename = "#{String.replace(name, [" ", "-"], "_")}_#{year}-#{year + 1}_icalendar.ics"
 
     conn
     |> put_resp_header("content-type", "text/calendar; charset=utf-8")

--- a/lib/mehr_schulferien_web/templates/federal_state/show.html.eex
+++ b/lib/mehr_schulferien_web/templates/federal_state/show.html.eex
@@ -128,3 +128,10 @@
     <%= render MehrSchulferienWeb.PartialView, "_jobs_panel.html" %>
   </div>
 </div>
+
+<%= link to: Routes.api_i_cal_path(@conn, :show, @federal_state.slug, vacation_types: "school", year: @current_year) do %>
+  Download ICalendar for <%= @current_year %>-<%= @current_year + 1 %>
+<% end %><br>
+<%= link to: Routes.api_i_cal_path(@conn, :show, @federal_state.slug, vacation_types: "school", year: @current_year + 1) do %>
+  Download ICalendar for <%= @current_year + 1 %>-<%= @current_year + 2 %>
+<% end %>

--- a/lib/mehr_schulferien_web/templates/school/show.html.eex
+++ b/lib/mehr_schulferien_web/templates/school/show.html.eex
@@ -99,11 +99,11 @@
   <svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="address-card" class="svg-inline--fa fa-address-card fa-w-18" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512"><path fill="currentColor" d="M528 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h480c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zm-352 96c35.3 0 64 28.7 64 64s-28.7 64-64 64-64-28.7-64-64 28.7-64 64-64zm112 236.8c0 10.6-10 19.2-22.4 19.2H86.4C74 384 64 375.4 64 364.8v-19.2c0-31.8 30.1-57.6 67.2-57.6h5c12.3 5.1 25.7 8 39.8 8s27.6-2.9 39.8-8h5c37.1 0 67.2 25.8 67.2 57.6v19.2zM512 312c0 4.4-3.6 8-8 8H360c-4.4 0-8-3.6-8-8v-16c0-4.4 3.6-8 8-8h144c4.4 0 8 3.6 8 8v16zm0-64c0 4.4-3.6 8-8 8H360c-4.4 0-8-3.6-8-8v-16c0-4.4 3.6-8 8-8h144c4.4 0 8 3.6 8 8v16zm0-64c0 4.4-3.6 8-8 8H360c-4.4 0-8-3.6-8-8v-16c0-4.4 3.6-8 8-8h144c4.4 0 8 3.6 8 8v16z"></path></svg>
             </i>
           <% end %><br>
-          <%= link to: Routes.api_i_cal_path(@conn, :show, @school.slug, vacation_types: "all") do %>
-            Download ICalendar for school vacations and public holidays
+          <%= link to: Routes.api_i_cal_path(@conn, :show, @school.slug, vacation_types: "school", year: @current_year) do %>
+            Download ICalendar for <%= @current_year %>-<%= @current_year + 1 %>
           <% end %><br>
-          <%= link to: Routes.api_i_cal_path(@conn, :show, @school.slug, vacation_types: "school") do %>
-            Download ICalendar for school vacations
+          <%= link to: Routes.api_i_cal_path(@conn, :show, @school.slug, vacation_types: "school", year: @current_year + 1) do %>
+            Download ICalendar for <%= @current_year + 1 %>-<%= @current_year + 2 %>
           <% end %>
           </p>
         <% else %>

--- a/test/mehr_schulferien_web/controllers/api/v2/i_cal_controller_test.exs
+++ b/test/mehr_schulferien_web/controllers/api/v2/i_cal_controller_test.exs
@@ -5,15 +5,26 @@ defmodule MehrSchulferienWeb.Api.V2.ICalControllerTest do
 
   setup %{conn: conn} do
     location = insert(:federal_state)
+    year = Date.utc_today().year
+    {:ok, start_date} = Date.new(year, 8, 1)
+    {:ok, end_date} = Date.new(year + 1, 7, 31)
     school_periods = add_school_periods(%{location: location})
-    public_periods = add_public_periods(%{location: location})
+
+    public_periods =
+      insert_list(3, :period, %{
+        is_public_holiday: true,
+        location_id: location.id,
+        starts_on: start_date,
+        ends_on: end_date
+      })
 
     {:ok,
      %{
        conn: conn,
        location: location,
        public_periods: public_periods,
-       school_periods: school_periods
+       school_periods: school_periods,
+       year: year
      }}
   end
 
@@ -21,16 +32,22 @@ defmodule MehrSchulferienWeb.Api.V2.ICalControllerTest do
     conn: conn,
     location: location,
     public_periods: public_periods,
-    school_periods: school_periods
+    school_periods: school_periods,
+    year: year
   } do
-    conn = get(conn, Routes.api_i_cal_path(conn, :show, location.slug, vacation_types: "school"))
+    conn =
+      get(
+        conn,
+        Routes.api_i_cal_path(conn, :show, location.slug, vacation_types: "school", year: year)
+      )
+
     assert conn.status == 200
     icalendar = conn.resp_body
     assert icalendar =~ "BEGIN:VCALENDAR\nCALSCALE:GREGORIAN"
-    school_period = get_random_period(school_periods)
+    school_period = get_random_period(school_periods, year)
     assert icalendar =~ "DESCRIPTION:#{school_period.holiday_or_vacation_type.name}"
     assert icalendar =~ "DTSTART:#{Date.to_iso8601(school_period.starts_on, :basic)}"
-    public_period = get_random_period(public_periods)
+    public_period = get_random_period(public_periods, year)
     refute icalendar =~ "DTSTART:#{Date.to_iso8601(public_period.starts_on, :basic)}"
   end
 
@@ -38,21 +55,37 @@ defmodule MehrSchulferienWeb.Api.V2.ICalControllerTest do
     conn: conn,
     location: location,
     public_periods: public_periods,
-    school_periods: school_periods
+    school_periods: school_periods,
+    year: year
   } do
-    conn = get(conn, Routes.api_i_cal_path(conn, :show, location.slug, vacation_types: "all"))
+    conn =
+      get(
+        conn,
+        Routes.api_i_cal_path(conn, :show, location.slug, vacation_types: "all", year: year)
+      )
+
     assert conn.status == 200
     icalendar = conn.resp_body
     assert icalendar =~ "BEGIN:VCALENDAR\nCALSCALE:GREGORIAN"
-    school_period = get_random_period(school_periods)
+    school_period = get_random_period(school_periods, year)
     assert icalendar =~ "DESCRIPTION:#{school_period.holiday_or_vacation_type.name}"
     assert icalendar =~ "DTSTART:#{Date.to_iso8601(school_period.starts_on, :basic)}"
-    public_period = get_random_period(public_periods)
+    public_period = get_random_period(public_periods, year)
     assert icalendar =~ "DTSTART:#{Date.to_iso8601(public_period.starts_on, :basic)}"
   end
 
-  defp get_random_period(periods) do
-    period = Enum.random(periods)
+  defp get_random_period(periods, year) do
+    {:ok, start_date} = Date.new(year, 8, 1)
+    {:ok, end_date} = Date.new(year + 1, 7, 31)
+
+    period =
+      periods
+      |> Enum.filter(
+        &(Date.compare(&1.starts_on, start_date) != :lt and
+            Date.compare(&1.starts_on, end_date) != :gt)
+      )
+      |> Enum.random()
+
     Periods.get_period!(period.id)
   end
 end


### PR DESCRIPTION
As part of #491 

* changed dates for calendars
    * now the icalendars are one-year long and for school years
* added links to the federal_state page
* removed links for icalendars with public periods
* changed how the filename is calculated
    * now the filename consists of the location name and the start year and end year