### PR TITLE
Refactor: Consolidate period fetching to PeriodFetcher module

### DIFF
--- a/lib/mehr_schulferien/periods.ex
+++ b/lib/mehr_schulferien/periods.ex
@@ -12,7 +12,8 @@ defmodule MehrSchulferien.Periods do
 
   alias MehrSchulferien.Calendars
   alias MehrSchulferien.Calendars.{DateHelpers, HolidayOrVacationType}
-  alias MehrSchulferien.Periods.{Period, Query, DateOperations, Grouping}
+  alias MehrSchulferien.Periods.{Period, DateOperations, Grouping}
+  alias MehrSchulferien.PeriodFetcher
   alias MehrSchulferien.Repo
 
   #
@@ -111,18 +112,18 @@ defmodule MehrSchulferien.Periods do
   end
 
   #
-  # Period queries by time - delegated to Query module
+  # Period queries by time - delegated to PeriodFetcher module
   #
 
-  defdelegate list_previous_periods(federal_state, holiday_or_vacation_type), to: Query
-  defdelegate list_current_and_future_periods(federal_state, holiday_or_vacation_type), to: Query
-  defdelegate list_school_vacation_periods(location_ids, starts_on, ends_on), to: Query
-  defdelegate list_public_everybody_periods(location_ids, starts_on, ends_on), to: Query
-  defdelegate list_public_periods(location_ids, starts_on, ends_on), to: Query
-  defdelegate list_school_free_periods(location_ids, starts_on, ends_on), to: Query
-  defdelegate list_school_free_periods_for_countries(countries, starts_on, ends_on), to: Query
-  defdelegate list_school_free_periods_with_preload(location_ids, starts_on, ends_on), to: Query
-  defdelegate list_years_with_periods(), to: Query
+  defdelegate list_previous_periods(federal_state, holiday_or_vacation_type), to: PeriodFetcher
+  defdelegate list_current_and_future_periods(federal_state, holiday_or_vacation_type), to: PeriodFetcher
+  defdelegate list_school_vacation_periods(location_ids, starts_on, ends_on), to: PeriodFetcher
+  defdelegate list_public_everybody_periods(location_ids, starts_on, ends_on), to: PeriodFetcher
+  defdelegate list_public_periods(location_ids, starts_on, ends_on), to: PeriodFetcher
+  defdelegate list_school_free_periods(location_ids, starts_on, ends_on), to: PeriodFetcher
+  defdelegate list_school_free_periods_for_countries(countries, starts_on, ends_on), to: PeriodFetcher
+  defdelegate list_school_free_periods_with_preload(location_ids, starts_on, ends_on), to: PeriodFetcher
+  defdelegate list_years_with_periods(), to: PeriodFetcher
 
   #
   # Period filtering and finding by date - delegated to DateOperations module

--- a/lib/mehr_schulferien/periods/period_fetcher.ex
+++ b/lib/mehr_schulferien/periods/period_fetcher.ex
@@ -1,4 +1,4 @@
-defmodule MehrSchulferien.Periods.Query do
+defmodule MehrSchulferien.PeriodFetcher do
   @moduledoc """
   Period query operations.
 


### PR DESCRIPTION
I renamed the `MehrSchulferien.Periods.Query` module to `MehrSchulferien.PeriodFetcher` to better reflect its responsibility.

I updated all references to the old module name:
- Modified `lib/mehr_schulferien/periods.ex` to alias and delegate to the new `PeriodFetcher` module.
- Corrected direct usages of the old module name in:
    - `lib/mehr_schulferien_web/templates/page/home.html.heex`
    - `lib/mehr_schulferien_web/controllers/city_controller.ex`
    - `lib/mehr_schulferien_web/controllers/federal_state_controller.ex`
    - `lib/mehr_schulferien_web/controllers/school_controller.ex`
    - `lib/mehr_schulferien/bridge_days.ex`
- Removed an unused alias for `Query` from `lib/mehr_schulferien/bridge_days.ex`.

This change aims to DRY up period fetching logic by centralizing it.

Note: The project's test suite is currently failing due to a pre-existing incompatibility between the `tidewave` dependency and Elixir 1.14.0. This issue is unrelated to the changes in this commit.